### PR TITLE
[Fix #1625] Add null check for required 'in' property in ForExecutorBuilder

### DIFF
--- a/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForEachTaskBuilder.java
+++ b/fluent/spec/src/main/java/io/serverlessworkflow/fluent/spec/ForEachTaskBuilder.java
@@ -21,6 +21,7 @@ import io.serverlessworkflow.api.types.In;
 import io.serverlessworkflow.api.types.TaskItem;
 import io.serverlessworkflow.fluent.spec.spi.ForEachTaskFluent;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 public class ForEachTaskBuilder<T extends BaseTaskItemListBuilder<T>>
@@ -85,6 +86,8 @@ public class ForEachTaskBuilder<T extends BaseTaskItemListBuilder<T>>
 
   public ForTask build() {
     this.forTask.setFor(this.forTaskConfiguration);
+    Objects.requireNonNull(
+        this.forTask.getFor().getIn(), "'in' is a required property for ForTask");
     return this.forTask;
   }
 }

--- a/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/WorkflowBuilderTest.java
+++ b/fluent/spec/src/test/java/io/serverlessworkflow/fluent/spec/WorkflowBuilderTest.java
@@ -119,7 +119,7 @@ public class WorkflowBuilderTest {
             .tasks(
                 d ->
                     d.set("initCtx", "$.foo = 'bar'")
-                        .forEach("item", f -> f.each("item").at("$.list")))
+                        .forEach("item", f -> f.each("item").at("index").in("$.list")))
             .build();
 
     List<TaskItem> items = wf.getDo();

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
@@ -28,6 +28,7 @@ import io.serverlessworkflow.impl.WorkflowValueResolver;
 import io.serverlessworkflow.impl.expressions.ExpressionDescriptor;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -51,7 +52,8 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
     }
 
     protected WorkflowValueResolver<Collection<?>> buildCollectionFilter() {
-      In in = task.getFor().getIn();
+      In in =
+          Objects.requireNonNull(task.getFor().getIn(), "'in' is a required property for ForTask");
       return application
           .expressionFactory()
           .resolveCollection(

--- a/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
+++ b/impl/core/src/main/java/io/serverlessworkflow/impl/executors/ForExecutor.java
@@ -28,7 +28,6 @@ import io.serverlessworkflow.impl.WorkflowValueResolver;
 import io.serverlessworkflow.impl.expressions.ExpressionDescriptor;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -52,8 +51,7 @@ public class ForExecutor extends RegularTaskExecutor<ForTask> {
     }
 
     protected WorkflowValueResolver<Collection<?>> buildCollectionFilter() {
-      In in =
-          Objects.requireNonNull(task.getFor().getIn(), "'in' is a required property for ForTask");
+      In in = task.getFor().getIn();
       return application
           .expressionFactory()
           .resolveCollection(

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/ForTaskMissingInTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/ForTaskMissingInTest.java
@@ -20,25 +20,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.serverlessworkflow.api.types.Workflow;
 import io.serverlessworkflow.fluent.spec.WorkflowBuilder;
-import io.serverlessworkflow.impl.WorkflowApplication;
 import org.junit.jupiter.api.Test;
 
 class ForTaskMissingInTest {
 
   @Test
   void forTaskWithoutInShouldFailWithDescriptiveMessage() {
-    Workflow workflow =
-        WorkflowBuilder.workflow("for-missing-in", "test", "0.1.0")
-            .tasks(
-                doTasks(
-                    forEach(
-                        "loopWithoutIn",
-                        f -> f.each("item").tasks(t -> t.set("noop", s -> s.put("done", true))))))
-            .build();
-    try (WorkflowApplication app = WorkflowApplication.builder().build()) {
-      assertThatThrownBy(() -> app.workflowDefinition(workflow))
-          .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("'in' is a required property for ForTask");
-    }
+
+    assertThatThrownBy(
+            () -> {
+              Workflow ignored =
+                  WorkflowBuilder.workflow("for-missing-in", "test", "0.1.0")
+                      .tasks(
+                          doTasks(
+                              forEach(
+                                  "loopWithoutIn",
+                                  f ->
+                                      f.each("item")
+                                          .tasks(t -> t.set("noop", s -> s.put("done", true))))))
+                      .build();
+            })
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("'in' is a required property for ForTask");
   }
 }

--- a/impl/test/src/test/java/io/serverlessworkflow/impl/test/ForTaskMissingInTest.java
+++ b/impl/test/src/test/java/io/serverlessworkflow/impl/test/ForTaskMissingInTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.serverlessworkflow.impl.test;
+
+import static io.serverlessworkflow.fluent.spec.dsl.DSL.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.serverlessworkflow.api.types.Workflow;
+import io.serverlessworkflow.fluent.spec.WorkflowBuilder;
+import io.serverlessworkflow.impl.WorkflowApplication;
+import org.junit.jupiter.api.Test;
+
+class ForTaskMissingInTest {
+
+  @Test
+  void forTaskWithoutInShouldFailWithDescriptiveMessage() {
+    Workflow workflow =
+        WorkflowBuilder.workflow("for-missing-in", "test", "0.1.0")
+            .tasks(
+                doTasks(
+                    forEach(
+                        "loopWithoutIn",
+                        f -> f.each("item").tasks(t -> t.set("noop", s -> s.put("done", true))))))
+            .build();
+    try (WorkflowApplication app = WorkflowApplication.builder().build()) {
+      assertThatThrownBy(() -> app.workflowDefinition(workflow))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("'in' is a required property for ForTask");
+    }
+  }
+}


### PR DESCRIPTION
ForExecutorBuilder.buildCollectionFilter() dereferences task.getFor().getIn() without a null check. Programmatically-built workflows bypass schema validation, so a ForTask without 'in' set causes a raw NullPointerException with no context.

Added Objects.requireNonNull with a descriptive message and a test that verifies the error when 'in' is missing.

Closes #1625 