### PR TITLE
Update codemodel dependency to 4.0.9.

### DIFF
--- a/generators/jackson/pom.xml
+++ b/generators/jackson/pom.xml
@@ -52,14 +52,12 @@
      <scope>provided</scope>
    </dependency>
    <dependency>
-     <groupId>com.sun.codemodel</groupId>
+     <groupId>org.glassfish.jaxb</groupId>
       <artifactId>codemodel</artifactId>
-      <version>2.6</version>
    </dependency>
    <dependency>
      <groupId>io.github.classgraph</groupId>
      <artifactId>classgraph</artifactId>
-     <version>4.8.193</version>
    </dependency>
    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,11 @@
         <version.com.networknt>2.0.0</version.com.networknt>
         <version.com.squareup.okhttp3.mockwebserver>5.5.0</version.com.squareup.okhttp3.mockwebserver>
         <version.io.cloudevents>5.0.0</version.io.cloudevents>
+        <version.io.github.classgraph.classgraph>4.8.193</version.io.github.classgraph.classgraph>
         <version.jakarta.validation>3.1.1</version.jakarta.validation>
         <version.jsonassert>1.5.2</version.jsonassert>
         <version.org.assertj>3.27.7</version.org.assertj>
+        <version.org.glassfish.codemodel>4.0.9</version.org.glassfish.codemodel>
         <version.org.junit.jupiter>6.1.3</version.org.junit.jupiter>
         <version.org.mockito>5.23.0</version.org.mockito>
         <version.org.slf4j>2.0.18</version.org.slf4j>
@@ -232,6 +234,16 @@
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar</artifactId>
                 <version>${version.com.github.os72.protoc.jar}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>codemodel</artifactId>
+                <version>${version.org.glassfish.codemodel}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${version.io.github.classgraph.classgraph}</version>
             </dependency>
             <!-- test -->
             <dependency>


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates codemodel dependency to the newest version. The dependency moved to a new groupId. 

**Additional information (if needed):**

I also moved the version definition of dependencies from the jackson module to the parent pom, so it is easier to maintain those versions. 