### PR TITLE
Removing logback because of LGPL license

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -73,9 +73,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
   <build>

--- a/impl/model/pom.xml
+++ b/impl/model/pom.xml
@@ -25,8 +25,9 @@
         <artifactId>assertj-core</artifactId>
     </dependency>
     <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/impl/persistence/mvstore/pom.xml
+++ b/impl/persistence/mvstore/pom.xml
@@ -21,9 +21,9 @@
           <artifactId>serverlessworkflow-persistence-tests</artifactId>
         </dependency>
         <dependency>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-          <scope>test</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/impl/test/pom.xml
+++ b/impl/test/pom.xml
@@ -83,8 +83,9 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
         <!-- Dependencies versions, please keep in alphabetical order -->
         <version.awaitility>4.3.0</version.awaitility>
         <version.com.google.protobuf.java>4.32.1</version.com.google.protobuf.java>
-        <version.ch.qos.logback>1.6.3</version.ch.qos.logback>
         <version.com.fasterxml.jackson>2.22.2</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.annotations>2.22</version.com.fasterxml.jackson.annotations>
         <version.com.networknt>2.0.7</version.com.networknt>
@@ -163,6 +162,7 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.org.slf4j}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.serverlessworkflow</groupId>
@@ -268,12 +268,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${version.org.mockito}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${version.ch.qos.logback}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
A check recently added by CNCF folks https://github.com/open-workflow-specification/sdk-java/pull/1672 do not like logback because is LGPL, replacing it. 